### PR TITLE
handle NOSCRIPT errors properly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1.2.0
+        uses: erlef/setup-beam@v1
         with:
           otp-version: 22.1
           elixir-version: 1.6.6
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1.2.0
+        uses: erlef/setup-beam@v1
         with:
           otp-version: 22.1
           elixir-version: 1.6.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 redis:
   image: redis
   ports:
-    - '6379'
+    - '6379:6379'
 
 flume:
   image: bitwalker/alpine-elixir:1.6.6

--- a/lib/flume/redis/client.ex
+++ b/lib/flume/redis/client.ex
@@ -9,6 +9,7 @@ defmodule Flume.Redis.Client do
   @decrby "DECRBY"
   @del "DEL"
   @evalsha "EVALSHA"
+  @eval "EVAL"
   @get "GET"
   @hgetall "HGETALL"
   @incr "INCR"
@@ -361,6 +362,10 @@ defmodule Flume.Redis.Client do
 
   def evalsha_command(args) do
     [@evalsha] ++ args
+  end
+
+  def eval_command(args) do
+    [@eval] ++ args
   end
 
   def hmget(hash_key_list) when hash_key_list |> is_list(),

--- a/lib/flume/redis/lock.ex
+++ b/lib/flume/redis/lock.ex
@@ -3,7 +3,7 @@ defmodule Flume.Redis.Lock do
 
   alias Flume.Redis.{Client, Script}
 
-  @release_lock_sha Script.sha(:release_lock)
+  @release_lock_script Script.compile(:release_lock)
 
   def acquire(
         lock_key,
@@ -25,13 +25,11 @@ defmodule Flume.Redis.Lock do
 
   def release(lock_key, token) do
     response =
-      Client.evalsha_command([
-        @release_lock_sha,
+      Script.eval(@release_lock_script, [
         _num_of_keys = 1,
         lock_key,
         token
       ])
-      |> Client.query()
 
     case response do
       {:ok, _count} ->

--- a/lib/flume/redis/script.ex
+++ b/lib/flume/redis/script.ex
@@ -16,11 +16,30 @@ defmodule Flume.Redis.Script do
     :ok
   end
 
-  @spec sha(binary) :: binary
-  def sha(script_name) do
-    script = Path.join(scripts_dir(), "#{script_name}.lua")
-    hash_sha = :crypto.hash(:sha, File.read!(script))
-    Base.encode16(hash_sha, case: :lower)
+  @spec compile(binary) :: {binary, binary}
+  def compile(script_name) do
+    script =
+      Path.join(scripts_dir(), "#{script_name}.lua")
+      |> File.read!()
+
+    hash_sha = :crypto.hash(:sha, script)
+    {script, Base.encode16(hash_sha, case: :lower)}
+  end
+
+  @spec eval({binary, binary}, List.t()) :: []
+  def eval({script, sha}, arguments) do
+    result =
+      Client.evalsha_command([sha | arguments])
+      |> Client.query()
+
+    case result do
+      {:error, %Redix.Error{message: "NOSCRIPT" <> _}} ->
+        Client.eval_command([script | arguments])
+        |> Client.query()
+
+      result ->
+        result
+    end
   end
 
   @spec scripts_dir() :: binary

--- a/lib/flume/redis/script.ex
+++ b/lib/flume/redis/script.ex
@@ -26,7 +26,7 @@ defmodule Flume.Redis.Script do
     {script, Base.encode16(hash_sha, case: :lower)}
   end
 
-  @spec eval({binary, binary}, List.t()) :: []
+  @spec eval({binary, binary}, List.t()) :: {:ok, term} | {:error, term}
   def eval({script, sha}, arguments) do
     result =
       Client.evalsha_command([sha | arguments])

--- a/test/flume/queue/manager_test.exs
+++ b/test/flume/queue/manager_test.exs
@@ -233,7 +233,8 @@ defmodule Flume.Queue.ManagerTest do
         job
       )
 
-      Manager.enqueue_processing_jobs(@namespace, DateTime.utc_now(), "test", 1)
+      Client.query!(["SCRIPT", "FLUSH"])
+      assert {:ok, _} = Manager.enqueue_processing_jobs(@namespace, DateTime.utc_now(), "test", 1)
 
       assert [] = Client.zrange!("#{@namespace}:queue:processing:test")
 


### PR DESCRIPTION
All the scripts are loaded on application startup and the SHAs are
used there after. Even though this would work most of the time, we
can't assume the script would be always cached. Redis server restart
could wipe the script cache.

Fallback to eval command if the evalsha failed. The eval command
caches the script, so subsequent evalsha should succeed.