### PR TITLE
There are few events that are not handled by default handler

### DIFF
--- a/lib/flume/instrumentation/default_event_handler.ex
+++ b/lib/flume/instrumentation/default_event_handler.ex
@@ -31,6 +31,10 @@ defmodule Flume.Instrumentation.DefaultEventHandler do
     Logger.info("#{app_name}/#{Instrumentation.format_event_name(event_name)} - #{value}")
   end
 
+  def handle(_, _, _, _) do
+    :ok
+  end
+
   defp metric_path(event_name, nil), do: Instrumentation.format_event_name(event_name)
 
   defp metric_path(event_name, module) do


### PR DESCRIPTION
Add a catch all clause so we don't crash on unhandled events

```
[error] Handler :low_pipeline has failed and has been detached. Class=:error
Reason=:function_clause
Stacktrace=[
  {Flume.Instrumentation.DefaultEventHandler, :handle,
   [[:low, :dequeue], %{count: 0, latency: 23, payload_size: 0}, %{}, nil],
   [file: 'lib/flume/instrumentation/default_event_handler.ex', line: 8]},
```