### PR TITLE
make sure not more than one fetch_event message is scheduled

### DIFF
--- a/test/support/echo_consumer.ex
+++ b/test/support/echo_consumer.ex
@@ -1,12 +1,21 @@
 defmodule EchoConsumer do
   use GenStage
 
-  def start_link(producer, owner, name: process_name) do
-    GenStage.start_link(__MODULE__, {producer, owner}, name: process_name)
+  def start_link(producer, owner, options) do
+    GenStage.start_link(
+      __MODULE__,
+      %{
+        producer: producer,
+        owner: owner,
+        max_demand: Keyword.get(options, :max_demand, 1),
+        min_demand: Keyword.get(options, :min_demand, 0)
+      },
+      name: Keyword.fetch!(options, :name)
+    )
   end
 
-  def init({producer, owner}) do
-    {:consumer, owner, subscribe_to: [{producer, min_demand: 0, max_demand: 1}]}
+  def init(%{producer: producer, owner: owner, min_demand: min_demand, max_demand: max_demand}) do
+    {:consumer, owner, subscribe_to: [{producer, min_demand: min_demand, max_demand: max_demand}]}
   end
 
   def handle_events(events, _, owner) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExUnit.start()
 # Start flume supervision tree
-Flume.start_link()
+Flume.Supervisor.start_link()


### PR DESCRIPTION
If a new fetch_events message is scheduled just based on the demand > 0 predicate, more than one message could be scheduled and this could lead to a backlog of fetch_events messages in the message queue

Make sure there are no outstanding schedule before adding a new schedule